### PR TITLE
Fixed application crash in DirectionsExample

### DIFF
--- a/IOSBoilerplate/DirectionsExample.m
+++ b/IOSBoilerplate/DirectionsExample.m
@@ -277,4 +277,10 @@
     return YES;
 }
 
+-(void)dealloc{
+    map.delegate = nil;
+    [super dealloc];
+}
+
+
 @end


### PR DESCRIPTION
Added delloc with setting map delegate to nil.
